### PR TITLE
Fix client generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Virtuoso is a bot orchestration framework built on Phoenix. Simply put, one plac
 3. Add `{:virtuoso, ">= 0.0.24"}` to mix.exs
 4. `mix deps.get`
 5. `mix virtuoso.gen.bot BotName`
-5. `mix virtuoso.gen.client BotName FbMessenger`
+5. `mix virtuoso.gen.client`
 6. `mix virtuoso.gen.routine BotName HelloWorld`
 7. Add webhook to router and skip csrf:
 

--- a/lib/mix/tasks/virtuoso.gen.client.ex
+++ b/lib/mix/tasks/virtuoso.gen.client.ex
@@ -9,32 +9,23 @@ defmodule Mix.Tasks.Virtuoso.Gen.Client do
   @doc """
   Given the application module will generate a webhook
   """
-  def run(args) do
-    [app_module | [_client_module]] = args
-
-    app_module
-    |> _get_bot_web_controller_directory
-    |> _generate_webhook(app_module)
+  def run(_args) do
+    _generate_webhook(_get_bot_web_controller_directory())
   end
 
-  def _generate_webhook(dir, app) do
+  def _generate_webhook(dir) do
     dir
     |> String.replace_suffix("", "webhook_controller.ex")
-    |> Generator.create_file(webhook_controller_template(app))
+    |> Generator.create_file(webhook_controller_template())
   end
 
-  def _get_bot_web_controller_directory(app_module) do
-    app_dir =
-      app_module
-      |> Macro.underscore()
-
-    File.cwd!()
-    |> String.replace_suffix("", "/lib/#{app_dir}_web/controllers/")
+  def _get_bot_web_controller_directory() do
+    web_path = Mix.Phoenix.context_app() |> Mix.Phoenix.web_path()
+    String.replace_suffix(File.cwd!(), "", "/#{web_path}/controllers/")
   end
 
-  def webhook_controller_template(app) do
-    web_module = "#{app}Web"
-
+  def webhook_controller_template() do
+    web_module = (Mix.Phoenix.context_app() |> to_string() |> Mix.Phoenix.inflect())[:web_module]
     """
     defmodule #{web_module}.WebhookController do
       use #{web_module}, :controller

--- a/test/mix/generators/client_generator_test.exs
+++ b/test/mix/generators/client_generator_test.exs
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Virtuoso.Gen.ClientTest do
         send(self(), {:mix_shell_input, :yes?, true})
         Gen.Client.run(["GraceKelly", "FbMessenger"])
 
-        assert_file("lib/grace_kelly_web/controllers/webhook_controller.ex", fn file ->
+        assert_file("lib/virtuoso_web/controllers/webhook_controller.ex", fn file ->
           assert file =~ """
                  def verify(conn, %{\"hub.mode\" => mode, \"hub.verify_token\" => token, \"hub.challenge\" => challenge}) do
                  """


### PR DESCRIPTION
The webhook controller should be generated inside the project web folder instead of creating a new web folder for it.
