### PR TITLE
Fix bot generator

### DIFF
--- a/lib/mix/tasks/virtuoso.gen.bot.ex
+++ b/lib/mix/tasks/virtuoso.gen.bot.ex
@@ -79,8 +79,6 @@ defmodule Mix.Tasks.Virtuoso.Gen.Bot do
   end
 
   def bot_interface_template(bot_module_name) do
-    bot_dir = bot_module_name |> Macro.underscore()
-
     """
     defmodule #{bot_module_name} do
       @moduledoc \"""

--- a/lib/mix/tasks/virtuoso.gen.bot.ex
+++ b/lib/mix/tasks/virtuoso.gen.bot.ex
@@ -91,11 +91,11 @@ defmodule Mix.Tasks.Virtuoso.Gen.Bot do
       alias #{bot_module_name}.Routine
 
       @recipient_ids [
-        Application.get_env(:#{bot_dir}, :fb_page_recipient_id)
+        Application.get_env(:#{Mix.Phoenix.context_app()}, :fb_page_recipient_id)
       ]
 
       @tokens %{
-        fb_page_access_token: Application.get_env(:#{bot_dir}, :fb_page_access_token)
+        fb_page_access_token: Application.get_env(:#{Mix.Phoenix.context_app()}, :fb_page_access_token)
       }
 
       @doc \"""
@@ -186,7 +186,7 @@ defmodule Mix.Tasks.Virtuoso.Gen.Bot do
       \"""
 
       @module_name_expanded  "Elixir.#{bot_module_name}.Routine."
-      @default_routine Application.get_env(:#{Macro.underscore(bot_module_name)}, :default_routine)
+      @default_routine Application.get_env(:#{Mix.Phoenix.context_app()}, :default_routine)
 
       @doc \"""
       Initiates a routine given a corresponding intent string.


### PR DESCRIPTION
Description
-----------

According to README instructions, we should set configs as:

```
config :project_name,
  fb_page_recipient_id: "",
  fb_page_access_token: ""
```

so that we can do `System.get_env(:project_name, :fb_page_recipient_id)` for example.

By trying to fetch using the bot name, it will result in a nil value.