### PR TITLE
Fix routine runner function

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ dev.exs at the bottom:
 
 dev.secret.exs:
 ```
-config :virtuoso, wit_server_access_token: ""
+config :virtuoso,
+  wit_server_access_token: "",
+  nlp: ""
 
 config :project_name,
   fb_page_recipient_id: "",
-  fb_page_access_token: ""
+  fb_page_access_token: "",
+  <bot-name>_default_routine: ""
 ```
 
 ### Supported Platforms

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ dev.exs at the bottom:
 dev.secret.exs:
 ```
 config :virtuoso,
-  wit_server_access_token: "",
-  nlp: ""
+  wit_server_access_token: ""
 
 config :project_name,
   fb_page_recipient_id: "",

--- a/lib/mix/tasks/virtuoso.gen.bot.ex
+++ b/lib/mix/tasks/virtuoso.gen.bot.ex
@@ -184,7 +184,7 @@ defmodule Mix.Tasks.Virtuoso.Gen.Bot do
       \"""
 
       @module_name_expanded  "Elixir.#{bot_module_name}.Routine."
-      @default_routine Application.get_env(:#{Mix.Phoenix.context_app()}, :default_routine)
+      @default_routine Application.get_env(:#{Mix.Phoenix.context_app()}, :#{Macro.underscore(bot_module_name)}_default_routine)
 
       @doc \"""
       Initiates a routine given a corresponding intent string.
@@ -200,7 +200,9 @@ defmodule Mix.Tasks.Virtuoso.Gen.Bot do
         |> apply(:run, impression)
       end
       def runner(_impression, _conversation_state) do
-        @default_routine.run()
+        @default_routine |> to_string()
+        |> String.to_existing_atom()
+        |> apply(:run, [])
       end
     end
     """

--- a/lib/mix/tasks/virtuoso.gen.bot.ex
+++ b/lib/mix/tasks/virtuoso.gen.bot.ex
@@ -200,7 +200,7 @@ defmodule Mix.Tasks.Virtuoso.Gen.Bot do
         |> apply(:run, impression)
       end
       def runner(_impression, _conversation_state) do
-        @default_routine |> to_string()
+        "Elixir." <> (to_string(@default_routine))
         |> String.to_existing_atom()
         |> apply(:run, [])
       end


### PR DESCRIPTION
Description
-----------

In the generated `Routine` module we use `Application.get_env/2` to retrieve the default routine. It comes as a string but we're appending the function `run()` to it which doesn't work because we should turn the string into a module first.

e.g.

```
== Compilation error in file lib/bot_name/routine.ex ==
** (CompileError) lib/bot_name/routine.ex:23: invalid call "BotName.Routine.HelloWorld".run()
    lib/bot_name/routine.ex:22: (module)
    (stdlib) erl_eval.erl:677: :erl_eval.do_apply/6
    (elixir) lib/kernel/parallel_compiler.ex:208: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/6
```

That string comes from configs:

```
config :project_name,
  default_routine: "BotName.Routine.HelloWorld"
```

We can also pass a module in the `Routine` module but the changes here should work for both cases.

Also I have changed the env variable `default_routine` to `<bot-name>_default_routine` once we're aiming to handle multiple bots. In that way we can have a default routine for each bot instead of a single one.