### PR TITLE
Update README instructions and fix wrong config var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ dev.exs at the bottom:
 
 dev.secret.exs:
 ```
-config :virtuoso, wit_server_access_token: ""
+config :virtuoso,
+  wit_server_access_token: "KGNCS5UWL7Y33B..."
 
 config :project_name,
-  fb_page_recipient_id: "",
-  fb_page_access_token: ""
+  fb_page_recipient_ids: [100002891787948, 100002891787123],
+  fb_page_access_token: "EAAEywOmMYuIBAFI7IN..."
 ```
 
 ### Supported Platforms

--- a/lib/memento_mori.ex
+++ b/lib/memento_mori.ex
@@ -6,10 +6,10 @@ defmodule MementoMori do
   alias MementoMori.SlowThinking
   alias MementoMori.Routine
 
-  @recipient_ids Application.get_env(:memento_mori, :fb_page_recipient_ids)
+  @recipient_ids Application.get_env(:virtuoso, :fb_page_recipient_ids)
 
   @tokens %{
-    fb_page_access_token: Application.get_env(:memento_mori, :fb_page_access_token)
+    fb_page_access_token: Application.get_env(:virtuoso, :fb_page_access_token)
   }
 
   @doc """

--- a/lib/mix/tasks/virtuoso.gen.bot.ex
+++ b/lib/mix/tasks/virtuoso.gen.bot.ex
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Virtuoso.Gen.Bot do
       alias #{bot_module_name}.Routine
 
       @recipient_ids [
-        Application.get_env(:#{Mix.Phoenix.context_app()}, :fb_page_recipient_id)
+        Application.get_env(:#{Mix.Phoenix.context_app()}, :fb_page_recipient_ids)
       ]
 
       @tokens %{


### PR DESCRIPTION
Description
-----------

According to the `Virtuoso.Bot` module each bot should have an array of recipient ids:

```
def get(recipient_id) do
  Map.bots()
  |> Enum.find(fn bot -> Enum.member?(bot.recipient_ids, recipient_id) end)
end
```

In the README we're instructing users to create configs in singular:

```
config :project_name,
  fb_page_recipient_id: ""
```

That makes the `get/1` function to fail because we can't interate over a single element.
e.g.
```
Enum.member?(100002891787948, 100002891787948)
=> ** (Protocol.UndefinedError) protocol Enumerable not implemented for 100002891787948
```
Also this PR should update the templates generators accordingly:

```
  @recipient_ids [
        Application.get_env(:#{Mix.Phoenix.context_app()}, :fb_page_recipient_ids)
      ]
```