### PR TITLE
Hardening: bounded conversation history + composite index (review todos 005/008/011)

### DIFF
--- a/lib/virtuoso/conversation.ex
+++ b/lib/virtuoso/conversation.ex
@@ -121,12 +121,20 @@ defmodule Virtuoso.Conversation do
     {:via, Registry, {Supervisor.registry(), conversation_id}}
   end
 
+  # How many recent turns to hold in process memory. The full history lives in
+  # the log (the audit/replay source); process state is a bounded working window,
+  # so rehydration cost and memory stay flat no matter how long a conversation
+  # runs. History is kept NEWEST-FIRST internally so appends are O(1); the
+  # responder receives it oldest-first via history/1.
+  @history_limit 100
+
   @impl true
   def init(conversation_id) do
-    # Rehydrate: state is a replay of the log, not an in-memory original.
+    # Rehydrate a bounded window from the log, newest-first in state.
     history =
       conversation_id
-      |> Log.events_for()
+      |> Log.recent_events_for(@history_limit)
+      |> Enum.reverse()
       |> Enum.map(&{&1.role, &1.content})
 
     {:ok, %{conversation_id: conversation_id, history: history}}
@@ -143,11 +151,20 @@ defmodule Virtuoso.Conversation do
         {:reply, replayed_reply(imp), state}
 
       {:ok, _inbound, :inserted} ->
-        history = state.history ++ [{:user, imp.text}]
-        reply = responder.(imp, state.history)
-        new_state = commit_reply(reply, imp, %{state | history: history})
+        # Responder sees history *before* this turn, oldest-first.
+        reply = responder.(imp, history(state))
+        state = push_history(state, {:user, imp.text})
+        new_state = commit_reply(reply, imp, state)
         {:reply, reply, new_state}
     end
+  end
+
+  # Oldest-first history for the responder (state holds it newest-first).
+  defp history(state), do: Enum.reverse(state.history)
+
+  # Prepend a turn (O(1)) and cap the working window to @history_limit.
+  defp push_history(state, entry) do
+    %{state | history: Enum.take([entry | state.history], @history_limit)}
   end
 
   # The reply previously logged for this message, or :noreply if none was
@@ -163,7 +180,7 @@ defmodule Virtuoso.Conversation do
   defp commit_reply({:reply, text}, imp, state) do
     reply_id = "#{imp.message_id}:reply"
     {:ok, _outbound, _status} = Log.append_outbound(imp.conversation_id, reply_id, text)
-    %{state | history: state.history ++ [{:assistant, text}]}
+    push_history(state, {:assistant, text})
   end
 
   defp commit_reply(:noreply, _imp, state), do: state

--- a/lib/virtuoso/conversation/log.ex
+++ b/lib/virtuoso/conversation/log.ex
@@ -98,6 +98,26 @@ defmodule Virtuoso.Conversation.Log do
     )
   end
 
+  @doc """
+  The most recent `limit` events for a conversation, oldest first.
+
+  Bounds rehydration cost: a long-lived conversation loads at most `limit` events
+  into process memory instead of its entire history. The LLM context window caps
+  useful history anyway, and the full log remains the audit source. Backed by the
+  composite `(conversation_id, id)` index, this is a pure ordered range scan.
+  """
+  @spec recent_events_for(String.t(), pos_integer()) :: [t()]
+  def recent_events_for(conversation_id, limit) do
+    query =
+      from(e in __MODULE__,
+        where: e.conversation_id == ^conversation_id,
+        order_by: [desc: e.id],
+        limit: ^limit
+      )
+
+    query |> Repo.all() |> Enum.reverse()
+  end
+
   @doc "Whether a dedup key has already been appended (idempotency check)."
   @spec processed?(String.t()) :: boolean()
   def processed?(dedup_key) do

--- a/lib/virtuoso/llm.ex
+++ b/lib/virtuoso/llm.ex
@@ -10,7 +10,7 @@ defmodule Virtuoso.LLM do
   Two capabilities:
 
     * `complete/2` — a single non-streaming request, returning the full message.
-    * `stream/2` — a streaming request; each chunk is delivered to a callback as
+    * `stream/3` — a streaming request; each chunk is delivered to a callback as
       it arrives. Streaming is what the user sees for generation, so first-token
       latency matters here.
 

--- a/lib/virtuoso/llm/anthropic.ex
+++ b/lib/virtuoso/llm/anthropic.ex
@@ -98,11 +98,14 @@ defmodule Virtuoso.LLM.Anthropic do
     end
   end
 
+  # Hoist a system message from anywhere in the list, not just the head — a
+  # mid-list system turn must not be silently dropped (which would leave the
+  # model unprompted). First system message wins.
   defp system_from_messages(messages) do
-    case messages do
-      [%{role: :system, content: content} | _] -> content
-      _ -> nil
-    end
+    Enum.find_value(messages, fn
+      %{role: :system, content: content} -> content
+      _ -> false
+    end)
   end
 
   defp user_messages(messages), do: Enum.reject(messages, &(&1.role == :system))

--- a/priv/repo/migrations/20260720175541_composite_conversation_index.exs
+++ b/priv/repo/migrations/20260720175541_composite_conversation_index.exs
@@ -1,0 +1,13 @@
+defmodule Virtuoso.Repo.Migrations.CompositeConversationIndex do
+  use Ecto.Migration
+
+  # Replace the single-column conversation_id index with a composite
+  # (conversation_id, id): replay (and bounded recent-replay) filters by
+  # conversation_id and orders by id, so the composite serves both the lookup
+  # and the sort as a pure index range scan — no separate sort step. The
+  # composite also covers the prefix lookup the single-column index did.
+  def change do
+    drop index(:conversation_events, [:conversation_id])
+    create index(:conversation_events, [:conversation_id, :id])
+  end
+end

--- a/test/virtuoso/conversation/log_test.exs
+++ b/test/virtuoso/conversation/log_test.exs
@@ -70,6 +70,26 @@ defmodule Virtuoso.Conversation.LogTest do
     end
   end
 
+  describe "recent_events_for/2" do
+    test "returns the most recent N events, oldest first" do
+      for i <- 1..10, do: Log.append_inbound(impression("conv-r", "m-#{i}", "msg-#{i}"))
+
+      recent = Log.recent_events_for("conv-r", 3)
+      assert Enum.map(recent, & &1.content) == ["msg-8", "msg-9", "msg-10"]
+    end
+
+    test "returns all events when fewer than the limit exist" do
+      Log.append_inbound(impression("conv-r", "m-1", "only"))
+      assert Log.recent_events_for("conv-r", 100) |> Enum.map(& &1.content) == ["only"]
+    end
+
+    test "scopes to the conversation" do
+      Log.append_inbound(impression("conv-a", "a1", "a"))
+      Log.append_inbound(impression("conv-b", "b1", "b"))
+      assert Log.recent_events_for("conv-a", 100) |> Enum.map(& &1.content) == ["a"]
+    end
+  end
+
   describe "processed?/1" do
     test "true only after the channel message has been appended" do
       imp = impression("conv-1", "m-1", "hello")

--- a/test/virtuoso/conversation_test.exs
+++ b/test/virtuoso/conversation_test.exs
@@ -114,5 +114,25 @@ defmodule Virtuoso.ConversationTest do
       assert {:reply, "recovered:2"} =
                Conversation.deliver(impression("conv-b", "m-2", "after"), responder: capture)
     end
+
+    test "the responder sees history oldest-first across several turns" do
+      Conversation.deliver(impression("conv-h", "m-1", "first"), responder: echo_responder())
+      Conversation.deliver(impression("conv-h", "m-2", "second"), responder: echo_responder())
+
+      # On the 3rd turn, history before it is: first, FIRST, second, SECOND —
+      # in chronological order.
+      capture = fn _imp, history -> {:reply, inspect(history)} end
+
+      assert {:reply, reply} =
+               Conversation.deliver(impression("conv-h", "m-3", "third"), responder: capture)
+
+      assert reply ==
+               inspect([
+                 {:user, "first"},
+                 {:assistant, "FIRST"},
+                 {:user, "second"},
+                 {:assistant, "SECOND"}
+               ])
+    end
   end
 end

--- a/test/virtuoso/llm/anthropic_test.exs
+++ b/test/virtuoso/llm/anthropic_test.exs
@@ -91,6 +91,44 @@ defmodule Virtuoso.LLM.AnthropicTest do
       assert headers["x-api-key"] == ["sk-test"]
       assert headers["anthropic-version"] == ["2023-06-01"]
     end
+
+    test "hoists a system message anywhere in the list (not just the head)" do
+      parent = self()
+
+      adapter = fn request ->
+        send(parent, {:outgoing, request})
+
+        body = %{
+          "content" => [%{"type" => "text", "text" => "ok"}],
+          "stop_reason" => "end_turn",
+          "usage" => %{}
+        }
+
+        {request, %Req.Response{status: 200, body: body}}
+      end
+
+      # No top-level :system; a system turn sits mid-list. It must be hoisted,
+      # not silently dropped (which would leave the model unprompted).
+      req = %{
+        model: "claude-opus-4-8",
+        messages: [
+          %{role: :user, content: "hi"},
+          %{role: :system, content: "Be terse."},
+          %{role: :user, content: "again"}
+        ]
+      }
+
+      assert {:ok, _} = Anthropic.complete(req, req_options: [adapter: adapter], api_key: "k")
+
+      assert_received {:outgoing, out}
+      decoded = Jason.decode!(out.body)
+      assert decoded["system"] == "Be terse."
+
+      assert decoded["messages"] == [
+               %{"role" => "user", "content" => "hi"},
+               %{"role" => "user", "content" => "again"}
+             ]
+    end
   end
 
   describe "complete/2 — typed errors" do

--- a/todos/005-complete-p2-unbounded-conversation-history.md
+++ b/todos/005-complete-p2-unbounded-conversation-history.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: complete
 priority: p2
 issue_id: "005"
 tags: [code-review, performance, memory, otp]
@@ -61,3 +61,12 @@ _(fill during triage)_
 
 ## Triage Decision
 **DEFERRED** — Real, but Medium effort touching rehydration + history representation. Not a Phase-1 *scope* blocker (no long-lived conversations in a not-yet-deployed framework). Do alongside the SlowThinking context-window work, before any real deployment. Pairs with 008.
+
+## Resolution (complete)
+**FIXED** (Solution A). Added `Log.recent_events_for/2` (last N, ordered, reversed);
+`Conversation.init/1` rehydrates a bounded window (@history_limit 100). History is
+held newest-first in state for O(1) prepend (`push_history/2`, capped with
+Enum.take), handed to the responder oldest-first via `history/1`. Full history
+remains in the log for audit. Tests: recent_events_for scope/limit, oldest-first
+responder order across turns; all existing rehydration/FIFO/exactly-once tests
+stay green. Landed with 008 (composite index).

--- a/todos/008-complete-p3-composite-conversation-index.md
+++ b/todos/008-complete-p3-composite-conversation-index.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: complete
 priority: p3
 issue_id: "008"
 tags: [code-review, performance, database]
@@ -46,3 +46,8 @@ _(fill during triage)_
 
 ## Triage Decision
 **DEFERRED** — One-line index migration; do it together with 005 (bounded replay) so the two land as a unit.
+
+## Resolution (complete)
+**FIXED**. New migration drops the single-column conversation_id index and creates
+composite (conversation_id, id), so replay/recent-replay is a pure ordered range
+scan with no sort step (and it covers the prefix lookup). Migrated clean.

--- a/todos/011-pending-p3-cleanup-and-docs.md
+++ b/todos/011-pending-p3-cleanup-and-docs.md
@@ -66,3 +66,14 @@ _(fill during triage)_
 
 ## Triage Decision
 **DEFERRED** — Low-risk batch. Item #5 (Anthropic drops a mid-list system prompt) has a real correctness edge — worth doing soon; the rest are cosmetic. Fold into the next touch of these files.
+
+## Partial Resolution (this pass)
+- **#5 (Anthropic mid-list system prompt dropped) — FIXED.** `system_from_messages`
+  now hoists a `:system` message from ANYWHERE in the list (Enum.find_value), not
+  just the head; a mid-list system turn is no longer silently dropped. Test added.
+- **#1 (stream/2 doc) — FIXED.** LLM moduledoc corrected to `stream/3`.
+- **#3 (Log.count) — DECISION: keep.** Verified it's used by conversation/log tests
+  as an assertion helper; not dead. Left in place.
+- Remaining items (#2 Impression enforce-keys dup, #4 ensure_started belt-and-
+  suspenders, #6 from_status default arg, #7 Impression :version prose) are
+  cosmetic and left for a later touch of those files.


### PR DESCRIPTION
## Summary

Clears the deferred Phase-1 review findings my triage flagged as the natural next unit — **before Phase 3 makes rehydration routine.** Horde handoffs and node kills will restart conversation processes frequently, and unbounded rehydration is exactly what gets worse under that load. Hardening now is correct ordering.

No new capability — this makes the existing single-node conversation layer production-safe.

## Findings resolved

### 005 (P2) — unbounded conversation history
Previously `Conversation.init/1` loaded the **entire** event log into process memory and appended with `history ++ [entry]` (O(n) per turn, O(n²) over a conversation). A long-lived conversation was a memory cliff and slow to rehydrate.

- `Log.recent_events_for/2` — loads the last N events (ordered, reversed in memory), not the whole history.
- `Conversation` rehydrates a **bounded window** (`@history_limit` 100). State holds history **newest-first** for O(1) prepend (`push_history/2`, capped with `Enum.take`); the responder receives it **oldest-first** (`history/1`), so its contract is unchanged.
- The full log remains the audit/replay source — process state is just a bounded working window.

### 008 (P3) — composite index
New migration drops the single-column `conversation_id` index and creates composite `(conversation_id, id)`. Replay and recent-replay filter by `conversation_id` and order by `id`, so this is now a **pure ordered index range scan — no sort step**. The composite also covers the prefix lookup the old index did.

### 011 (P3, partial) — cleanup
- **Real correctness fix:** `Anthropic.system_from_messages` now hoists a `:system` message from **anywhere** in the list, not just the head. A mid-list system turn (with no top-level `:system`) was previously **silently dropped**, leaving the model unprompted. Test added.
- `LLM` moduledoc `stream/2` → `stream/3`.
- Verified `Log.count/0` is still used by tests (not dead) — kept. Remaining cosmetic items left for a later touch.

## Testing
- **+5 tests (150 total).** `recent_events_for/2` scope/limit/ordering; the responder sees history oldest-first across turns; the mid-list system-prompt hoist. **All existing rehydration / FIFO / exactly-once / thinking-pipeline tests stay green** — this refactor preserves behavior.
- Conversation + thinking e2e hammered 10× (the history path underlies both) — stable.
- `dialyzer`, `credo --strict`, `mix compile --warnings-as-errors` all clean.

## Post-Deploy Monitoring & Validation
`No additional operational monitoring required: library-internal hardening on a feature branch.` The new migration (`composite_conversation_index`) is index-only (drop + create), no data change; verify it applies clean on deploy (`mix ecto.migrate`).

## Todos
`005` and `008` marked complete in `todos/`; `011` partially resolved with notes on what was done vs. deferred.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)