### PR TITLE
Phase 4: DX & publish prep — generators, prompt files, migrations, dashboard auth, 0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ cover/
 # Example apps manage their own builds/deps
 /examples/*/_build
 /examples/*/deps
+/virtuoso-*.tar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## 0.1.0 (2026-07-21)
+
+First release of the rebuilt framework — a ground-up rewrite of the 2018
+Phoenix chatbot framework as a BEAM-native AI-agent orchestration library.
+
+### Added
+
+- **Ensemble consensus**: parallel LLM member fan-out with `Majority`, `Quorum`,
+  and `Judge` strategies, partial-failure tolerance, and per-run telemetry.
+  Offline eval harness (`mix virtuoso.eval`) demonstrating the accuracy lift.
+- **Conversation processes** over an append-only Postgres event log with
+  dedup-key exactly-once semantics; rehydration from the log on start, crash,
+  or failover. `Virtuoso.Migrations` for host-app migrations.
+- **Thinking pipeline**: FastThinking (deterministic, zero-token matchers) →
+  SlowThinking (ensemble routing over a string-keyed routine registry).
+- **Bot API**: `use Virtuoso.Bot` with prompt-file system prompts, per-routine
+  ensemble overrides, and a plug-in `responder/1`.
+- **Generators**: `mix virtuoso.gen.bot`, `mix virtuoso.gen.routine`,
+  `mix virtuoso.gen.tool`.
+- **LLM layer**: provider behaviour with a Req-based Anthropic adapter
+  (completion + SSE streaming), typed errors, and shape-only telemetry.
+- **Budget**: daily per-conversation/global token caps, kill switch, defined
+  refusal fallback; cluster-wide singleton when the fabric is enabled.
+- **Distributed fabric** (optional): Horde-backed registry/supervision with
+  libcluster formation; automatic conversation failover, chaos-drill tested.
+- **Dashboard example** (`examples/dashboard`): live ensemble runs — votes,
+  dissent, latency, cost — from telemetry alone, with a host-provided auth hook.
+- `config :virtuoso, :start_repo, false` escape hatch for LLM/Ensemble-only use.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2026 Justus Eapen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,112 +2,159 @@
 
 > "For as the body is one, and hath many members, and all the members of that one body, being many, are one body..."
 
-Virtuoso is a **BEAM-native AI-agent orchestration framework**. It runs many
-lightweight processes to reason with LLMs concurrently, aggregates their
-structured outputs by consensus, and (in later phases) spreads conversations
-across a self-healing cluster — the actor model applied to agent orchestration.
+Virtuoso is a **BEAM-native AI-agent orchestration framework**: the actor model
+applied to LLM agents.
 
-It is a rebuild of the original 2018 Phoenix chatbot framework: the cognitive
-shape is kept (a deterministic fast path ahead of an LLM reasoning step), but the
-pre-LLM NLP guts (Wit.ai / Watson intent classification) are replaced with LLM
-ensembles behind a clean behaviour.
+- **Parallel consensus (ensembles).** N lightweight processes query LLMs
+  concurrently; their *structured* outputs are aggregated by vote (majority,
+  quorum, or an LLM judge). Independently-noisy members cancel each other's
+  errors — in the bundled offline eval, majority-of-5 lifts accuracy from
+  **59.7% → 88.9%** at a 35% per-member error rate (`mix virtuoso.eval`).
+- **Distributed compute fabric.** Conversations and singletons run on a
+  [Horde](https://hex.pm/packages/horde)-backed cluster: a node dies, its
+  processes restart on survivors in tens of milliseconds and rehydrate from the
+  event log. Correctness never rests on the registry — it rests on the log.
+- **Exactly-once on at-least-once delivery.** An append-only Postgres event log
+  with a unique dedup key is the source of truth: duplicate webhooks collapse to
+  one event, replies to replayed messages are served from the log, and a crashed
+  conversation loses at most the in-flight message.
 
-> **Status:** Phase 1 — a useful modern single-node framework. The ensemble
-> (parallel consensus) and fabric (distributed compute) layers are the eventual
-> flagship features; see `docs/plans/` for the roadmap.
+Consensus is on **decisions, not text**: the ensemble votes on categorical
+outputs (routes, classifications, extractions), then the winning routine
+generates the reply or performs the side effect **once**. N members never mean
+N replies or N side effects.
 
-## Architecture (Phase 1)
+## Five-minute bot
+
+```sh
+mix virtuoso.gen.bot Demo
+```
+
+That scaffolds a complete bot — a FastThinking greeting matcher (deterministic,
+zero tokens), a starter routine reached by ensemble routing, and the routing
+system prompt as a **file** (`priv/prompts/demo/router.md`, embedded at compile
+time):
+
+```elixir
+imp = Virtuoso.Impression.new(
+  channel: :console, conversation_id: "c1", sender_id: "u1",
+  message_id: "m1", text: "hi"
+)
+
+Demo.Bot.responder().(imp, %{})
+#=> {:reply, "Hello! I'm Demo — ask me anything."}   # no API key needed
+```
+
+With `ANTHROPIC_API_KEY` set, non-greeting messages route through the ensemble
+to your routines. Add more with `mix virtuoso.gen.routine Demo Booking` and
+`mix virtuoso.gen.tool Demo Weather` (a *tool* is a routine whose job is a side
+effect, guaranteed post-consensus).
+
+## Installation
+
+```elixir
+def deps do
+  [{:virtuoso, "~> 0.1"}]
+end
+```
+
+Create the event log from your app's migration (the Oban pattern):
+
+```elixir
+defmodule MyApp.Repo.Migrations.AddVirtuoso do
+  use Ecto.Migration
+
+  def up, do: Virtuoso.Migrations.up()
+  def down, do: Virtuoso.Migrations.down()
+end
+```
+
+Point Virtuoso's repo at your Postgres:
+
+```elixir
+config :virtuoso, Virtuoso.Repo, url: System.get_env("DATABASE_URL")
+```
+
+Only using the LLM/Ensemble layers (no conversations)? Skip Postgres entirely:
+
+```elixir
+config :virtuoso, :start_repo, false
+```
+
+## Architecture
 
 ```
-channel → Impression v1 → conversation process → responder → reply
-             (translate)      (FIFO, rehydrates      (thinking
-                               from event log)        pipeline)
-                    │                                     │
-              event log ◀────── append inbound/outbound (dedup) ──────▶ event log
-                    │                                     │
+channel → Impression v1 → conversation process → thinking pipeline → reply
+             (translate)      (FIFO, rehydrates     Fast (0 tokens)
+                               from event log)      → Slow (ensemble routes,
+                    │                                  routine replies once)
+              event log ◀── append inbound/outbound (dedup) ──▶ event log
+                    │
               every LLM call passes the Budget gate and emits telemetry
 ```
 
-- **`Virtuoso.Impression`** — the channel-neutral, versioned message envelope
-  every channel translates to and from. `dedup_key/1` (`"<channel>:<id>"`) is the
-  event log's idempotency key.
-- **`Virtuoso.Conversation`** — one GenServer per conversation, addressed by a
-  Registry and started on demand. FIFO ordering per conversation falls out of the
-  serial mailbox; state is rehydrated from the event log on start, so a crash
-  loses at most the in-flight message.
-- **`Virtuoso.Conversation.Log`** — append-only Postgres event log, the source of
-  truth. A unique index on the dedup key gives exactly-once processing (a
-  duplicate webhook yields one event); recording outbound send-intent *before* the
-  channel send prevents double-sends.
-- **`Virtuoso.LLM`** — the behaviour every provider implements (`complete/2`,
-  `stream/3`), with a Req-based Anthropic adapter and typed `Virtuoso.LLM.Error`s
-  (429 → `:rate_limited`, 529 → `:overloaded`, timeout, …). Tests run fully
-  offline against `Virtuoso.LLM.Mock`.
-- **`Virtuoso.Budget`** — cluster-global token caps (per-conversation + global
-  daily) with a kill switch and a defined refusal fallback. Every LLM call is
-  gated.
-- **`Virtuoso.Routine`** — explicit string-keyed routine registry (replaces the
-  legacy `String.to_atom` dispatch and its atom-exhaustion DoS).
-- **`Virtuoso.Channel`** — the behaviour a channel adapter implements
-  (`translate_in/1`, `send_out/2`, `verify_webhook/2`). Web chat is first-class;
-  `Virtuoso.Channel.Signature` provides reusable HMAC-SHA256 webhook verification.
-
-The library core is **Phoenix-free**. Channel transports (Phoenix Channels /
-LiveView) and the telemetry dashboard live in an optional host application.
-
-## Public API & extension points
-
-Implement these behaviours to extend the framework:
-
-| Behaviour | Implement to… |
+| Module | Role |
 |---|---|
-| `Virtuoso.LLM` | add an LLM provider |
-| `Virtuoso.Channel` | add a messaging channel |
-| `Virtuoso.Routine` | add a routine/tool |
+| `Virtuoso.Bot` | `use Virtuoso.Bot` — declare fast-thinkers, routines, ensemble defaults, and the prompt file; get a plug-in `responder/1` |
+| `Virtuoso.Ensemble` | parallel member fan-out + consensus strategies (`Majority`, `Quorum`, `Judge`) with partial-failure tolerance |
+| `Virtuoso.Conversation` | one process per conversation; serial mailbox = FIFO; rehydrates from the log on start/failover |
+| `Virtuoso.Conversation.Log` | append-only Postgres event log; unique dedup index = exactly-once |
+| `Virtuoso.LLM` | provider behaviour (`complete/2`, `stream/3`); Req-based Anthropic adapter with typed errors; offline mock for tests |
+| `Virtuoso.Budget` | daily token caps (per-conversation + global) with kill switch and a defined refusal fallback; cluster-wide singleton on the fabric |
+| `Virtuoso.Fabric` | seam between single-node (Registry/DynamicSupervisor) and clustered (Horde) process placement |
+| `Virtuoso.Channel` | channel adapter behaviour + HMAC-SHA256 webhook verification |
 
-### Telemetry (stable, versioned from 0.1.0)
+The library core is **Phoenix-free**. The live telemetry dashboard (votes,
+dissent, latency, cost per decision) is a host app in `examples/dashboard`.
 
-Every LLM call through `Virtuoso.LLM.complete/2` and `stream/3` emits:
+## Clustering (optional)
 
-- `[:virtuoso, :llm, :complete | :stream, :start]` — `%{system_time}`;
-  metadata `%{model, request}`
-- `[:virtuoso, :llm, :complete | :stream, :stop]` — `%{duration}`;
-  metadata `%{model, outcome, usage, error_reason}`
-- `[:virtuoso, :llm, :complete | :stream, :exception]` — on a raised bug;
-  re-raised after the event
+```elixir
+config :virtuoso, Virtuoso.Fabric, enabled: true
+config :virtuoso, Virtuoso.Fabric, topologies: [
+  fly: [strategy: Cluster.Strategy.DNSPoll, config: [query: "myapp.internal", ...]]
+]
+```
 
-## Getting started (development)
+With the fabric on, conversations distribute across nodes and fail over
+automatically (measured 52–307ms in the chaos drills, target was 5s). See
+`docs/operations/rolling-deploys.md` for deploy invariants and
+`docs/spikes/2026-07-20-horde-spike-report.md` for the drill findings.
 
-Requires Elixir **1.15.6-otp-26** (pinned in `.tool-versions`) and a local
+## Telemetry (stable, versioned from 0.1.0)
+
+- `[:virtuoso, :llm, :complete | :stream, :start | :stop | :exception]` —
+  durations, model, outcome, token usage. **Shape-only: never transcripts**
+  (enforced by test — safe to ship to any metrics backend).
+- `[:virtuoso, :ensemble, :run, :start | :stop]` — outcome, decision (a
+  categorical label, not user text), vote count, members ok/dropped, usage.
+
+## Budget
+
+```elixir
+config :virtuoso, Virtuoso.Budget,
+  per_conversation_daily: 50_000,
+  global_daily: 1_000_000
+```
+
+Caps are genuinely daily (they reset at UTC rollover), the kill switch refuses
+everything immediately, and an over-budget turn gets a defined refusal message
+instead of spending. The N-members multiplier is structural, so the gate is not
+optional.
+
+## Development
+
+Requires Elixir **1.15.6-otp-26** (pinned in `.tool-versions`) and local
 Postgres.
 
 ```sh
 mix deps.get
-mix ecto.setup      # create + migrate the dev database
-mix test            # full suite — offline (no live LLM); needs local Postgres
+mix ecto.setup
+mix test                        # fully offline (mock LLM); needs Postgres
+mix test --include distributed  # multi-node chaos drills
+mix virtuoso.eval               # the consensus accuracy proof
 ```
-
-Configure the Anthropic API key (the default adapter reads it from the
-environment):
-
-```sh
-export ANTHROPIC_API_KEY="sk-ant-..."
-```
-
-Caps and adapter are configurable:
-
-```elixir
-# config/config.exs
-config :virtuoso, :llm, Virtuoso.LLM.Anthropic
-config :virtuoso, Virtuoso.Budget, per_conversation_daily: 50_000, global_daily: 1_000_000
-```
-
-## Testing
-
-`mix test` is fully offline — the LLM behaviour is served by an in-process mock,
-so no request ever hits the network. It does require a local Postgres (the event
-log is the persistence layer); "offline" means no live LLM, not no database.
 
 ## License
 
-MIT
+MIT — see [LICENSE](https://github.com/justuseapen/virtuoso/blob/master/LICENSE).

--- a/docs/plans/2026-07-17-refactor-virtuoso-beam-ai-orchestration-rebuild-plan.md
+++ b/docs/plans/2026-07-17-refactor-virtuoso-beam-ai-orchestration-rebuild-plan.md
@@ -156,11 +156,16 @@ lib/virtuoso/
 - **Success:** kill -9 a node mid-conversation → conversation resumes on another node ≤ 5s with at most the in-flight message lost; 3-node partition/heal drill produces no duplicate outbound sends; suite still passes single-node with no cluster config
 
 #### Phase 4: Developer experience & polish
-- [ ] Generators updated: `virtuoso.gen.bot` (agent + FastThinking + prompts), `virtuoso.gen.routine`, `virtuoso.gen.tool`
-- [ ] Prompt/agent definitions as files scaffolded by generators (not inline strings)
-- [ ] Dashboard auth (host-app-provided plug), PII policy: transcripts redacted in telemetry/logs
-- [ ] README + hexdocs rewrite; publish `0.1.0` to Hex
+- [x] Generators updated: `virtuoso.gen.bot` (agent + FastThinking + prompts), `virtuoso.gen.routine`, `virtuoso.gen.tool`
+      → **Done:** `mix virtuoso.gen.bot Demo` scaffolds bot module + FastThinking greeting matcher (chats with zero tokens, no API key) + starter routine + prompt file; `gen.routine`/`gen.tool` scaffold registry-ready modules and print the registry entry (tools = post-consensus side-effect routines in 0.1.0). Tests generate into a tmp dir, compile the output, and drive the bot through `responder/1` with a crashing `:llm` seam to prove the zero-token path.
+- [x] Prompt/agent definitions as files scaffolded by generators (not inline strings)
+      → **Done:** `priv/prompts/<bot>/router.md` embedded at compile time via `@external_resource` (edits recompile). New core seam: `Virtuoso.Bot.system/0` overridable callback threads the prompt into SlowThinking; `:system` replaces only the router *preamble* — the valid-intent list is always appended, so a prompt file can't silently break routing.
+- [x] Dashboard auth (host-app-provided plug), PII policy: transcripts redacted in telemetry/logs
+      → **Done:** `config :virtuoso_dashboard, :auth, MyPlug | {MyPlug, opts}` consulted in the browser pipeline (unset = open, documented dev-only). PII policy documented in the dashboard README: transcripts live only in the event log; telemetry is shape-only (test-enforced); ensemble `decision` is a categorical label, never user text.
+- [x] README + hexdocs rewrite; publish `0.1.0` to Hex
+      → **Docs done:** README rewritten around the 0.1.0 surface (flagship numbers, 5-minute bot, `Virtuoso.Migrations` Oban-style install, `start_repo: false` escape hatch, clustering, telemetry contract); CHANGELOG.md added; MIT LICENSE added; ex_doc extras (README/CHANGELOG/rolling-deploys/spike report) + module groups; version `0.1.0`; `mix docs` zero warnings; `mix hex.build` produces a valid package. **Publish itself awaits explicit approval** (irreversible; needs the maintainer's Hex auth).
 - **Success:** `mix virtuoso.gen.bot Demo` produces a compiling, chatting bot in < 5 min from a fresh app
+      → Verified by test: generated files compile and the bot replies to "hi" via FastThinking with no API key and zero LLM calls.
 
 ## Alternative Approaches Considered
 

--- a/examples/dashboard/README.md
+++ b/examples/dashboard/README.md
@@ -27,5 +27,34 @@ framework's independently-noisy eval members (offline, no API key), and the
 run's votes/dissent/cost stream onto the page live. Roughly a third of runs
 show dissent or fall back, which is the interesting part.
 
-Dev-only: static secrets, `check_origin: false`, no auth (a host-provided auth
-plug is the Phase 4 item). Do not deploy as-is.
+## Auth
+
+The browser pipeline consults a host-provided plug on every request:
+
+```elixir
+config :virtuoso_dashboard, :auth, MyApp.AdminAuth
+# or with options:
+config :virtuoso_dashboard, :auth, {MyApp.BasicAuth, realm: "dashboard"}
+```
+
+Any plug works — e.g. `Plug.BasicAuth` wrapped in a module, or your app's
+existing admin auth. Unset means **open access**: fine on localhost, never in
+production.
+
+Dev-only defaults elsewhere too: static secrets and `check_origin: false`.
+Do not deploy as-is.
+
+## PII policy
+
+The dashboard never sees message content, by construction:
+
+- **Transcripts live only in the event log** (`conversation_events` in the
+  host's Postgres). Nothing here reads it.
+- **Telemetry is shape-only.** LLM start/stop events carry counts, durations,
+  model names, and token usage — no prompts, no completions. This is enforced
+  by a test in the framework (`llm_test.exs`), not just convention.
+- **Ensemble events carry decisions, not text.** The `decision` shown per run
+  is a categorical routing label (a routine name), never user input.
+
+So the dashboard can be shown on a team screen without leaking conversations —
+the only trust boundary you must add is the auth plug above.

--- a/examples/dashboard/lib/dashboard_web/router.ex
+++ b/examples/dashboard/lib/dashboard_web/router.ex
@@ -10,11 +10,27 @@ defmodule VirtuosoDashboardWeb.Router do
     plug :fetch_session
     plug :protect_from_forgery
     plug :put_root_layout, html: {VirtuosoDashboardWeb.Layouts, :root}
+    plug :dashboard_auth
   end
 
   scope "/", VirtuosoDashboardWeb do
     pipe_through :browser
 
     live "/", DashboardLive
+  end
+
+  # Host-provided auth hook: point the config at any plug and every dashboard
+  # request goes through it before rendering.
+  #
+  #     config :virtuoso_dashboard, :auth, MyApp.AdminAuth
+  #     config :virtuoso_dashboard, :auth, {MyApp.BasicAuth, realm: "dashboard"}
+  #
+  # Unset → open access (dev only; the README says so out loud).
+  defp dashboard_auth(conn, _opts) do
+    case Application.get_env(:virtuoso_dashboard, :auth) do
+      nil -> conn
+      {plug, opts} -> plug.call(conn, plug.init(opts))
+      plug when is_atom(plug) -> plug.call(conn, plug.init([]))
+    end
   end
 end

--- a/lib/mix/tasks/virtuoso.gen.bot.ex
+++ b/lib/mix/tasks/virtuoso.gen.bot.ex
@@ -1,0 +1,156 @@
+defmodule Mix.Tasks.Virtuoso.Gen.Bot do
+  @shortdoc "Generates a Virtuoso bot: bot module, fast-thinker, starter routine, prompt file"
+
+  @moduledoc """
+  Generates a complete, working bot under your app's `lib/` and `priv/`:
+
+      mix virtuoso.gen.bot Demo
+
+  creates
+
+    * `lib/demo/bot.ex` — `Demo.Bot`, wired with `use Virtuoso.Bot`
+    * `lib/demo/fast/greeting.ex` — a zero-token FastThinking matcher
+      (the bot chats immediately, no API key required)
+    * `lib/demo/routines/echo.ex` — a starter routine reached via ensemble routing
+    * `priv/prompts/demo/router.md` — the routing system prompt as a **file**,
+      embedded at compile time (`@external_resource` recompiles on edit)
+
+  The namespace may be nested (`mix virtuoso.gen.bot MyApp.Support`).
+
+  Try it in IEx:
+
+      imp = Virtuoso.Impression.new(
+        channel: :console, conversation_id: "c1", sender_id: "u1",
+        message_id: "m1", text: "hi"
+      )
+      Demo.Bot.responder().(imp, %{})
+      #=> {:reply, "Hello! I'm Demo — ..."}
+  """
+
+  use Mix.Task
+
+  import Mix.Generator
+
+  alias Mix.Virtuoso, as: Gen
+
+  @impl true
+  def run(argv) do
+    case argv do
+      [name | _] ->
+        {module, path} = Gen.module_arg!(name, "bot namespace")
+        generate(module, path)
+
+      [] ->
+        Mix.raise("Expected a bot namespace, e.g.: mix virtuoso.gen.bot Demo")
+    end
+  end
+
+  defp generate(module, path) do
+    assigns = [module: module, path: path]
+
+    create_file(Path.join(["lib", path, "bot.ex"]), bot_template(assigns))
+    create_file(Path.join(["lib", path, "fast", "greeting.ex"]), greeting_template(assigns))
+    create_file(Path.join(["lib", path, "routines", "echo.ex"]), echo_template(assigns))
+    create_file(Path.join(["priv", "prompts", path, "router.md"]), prompt_template(assigns))
+
+    Mix.shell().info("""
+
+    #{module}.Bot is ready. Wire it into a conversation:
+
+        Virtuoso.Conversation.deliver(impression, responder: #{module}.Bot.responder())
+
+    The greeting fast-thinker replies without an API key; ensemble routing to
+    routines needs ANTHROPIC_API_KEY (or an injected :llm adapter in tests).
+    Add routines with: mix virtuoso.gen.routine #{module} MyRoutine
+    """)
+  end
+
+  embed_template(:bot, """
+  defmodule <%= @module %>.Bot do
+    @moduledoc \"\"\"
+    A Virtuoso bot: FastThinking matchers first (zero tokens), then ensemble
+    routing over the routine registry, then the winning routine replies.
+    \"\"\"
+
+    use Virtuoso.Bot
+
+    # The routing prompt lives in a file, embedded at compile time.
+    # @external_resource recompiles this module when the file changes.
+    @router_prompt_path "priv/prompts/<%= @path %>/router.md"
+    @external_resource @router_prompt_path
+    @router_prompt File.read!(@router_prompt_path)
+
+    @impl true
+    def system, do: @router_prompt
+
+    @impl true
+    def fast, do: [<%= @module %>.Fast.Greeting]
+
+    @impl true
+    def routines do
+      %{
+        "echo" => <%= @module %>.Routines.Echo
+      }
+    end
+
+    # Ensemble defaults for routing; override per routine with
+    # {module, ensemble: [n: 5, strategy: :judge]}.
+    @impl true
+    def ensemble, do: [n: 3, strategy: :majority]
+  end
+  """)
+
+  embed_template(:greeting, """
+  defmodule <%= @module %>.Fast.Greeting do
+    @moduledoc \"\"\"
+    A FastThinking matcher: answers greetings deterministically, spending zero
+    tokens. Anything else falls through to ensemble routing.
+    \"\"\"
+
+    @behaviour Virtuoso.Thinking.Fast
+
+    alias Virtuoso.Impression
+
+    @greetings ~w(hi hello hey howdy yo)
+
+    @impl true
+    def match(%Impression{text: text}, _context) when is_binary(text) do
+      if String.downcase(String.trim(text)) in @greetings do
+        {:match, {:reply, "Hello! I'm <%= @module %> — ask me anything."}}
+      else
+        :no_match
+      end
+    end
+
+    def match(_impression, _context), do: :no_match
+  end
+  """)
+
+  embed_template(:echo, """
+  defmodule <%= @module %>.Routines.Echo do
+    @moduledoc \"\"\"
+    A starter routine. The ensemble votes on the route; the winning routine runs
+    exactly once (side effects happen post-consensus, never per member).
+    \"\"\"
+
+    @behaviour Virtuoso.Routine
+
+    alias Virtuoso.Impression
+
+    @impl true
+    def run(%Impression{text: text}, _context) do
+      {:reply, "You said: \#{text}"}
+    end
+  end
+  """)
+
+  embed_template(:prompt, """
+  You are the router for <%= @module %>, a helpful assistant.
+
+  Read the user's message and choose the single intent that best handles it.
+  Prefer a specific intent over a general one when both could apply.
+
+  <!-- The framework appends the valid intent list and reply format after this
+       preamble, so you never need to list routine names here. -->
+  """)
+end

--- a/lib/mix/tasks/virtuoso.gen.routine.ex
+++ b/lib/mix/tasks/virtuoso.gen.routine.ex
@@ -1,0 +1,71 @@
+defmodule Mix.Tasks.Virtuoso.Gen.Routine do
+  @shortdoc "Generates a Virtuoso routine module"
+
+  @moduledoc """
+  Generates a routine under an existing bot namespace:
+
+      mix virtuoso.gen.routine Demo Booking
+
+  creates `lib/demo/routines/booking.ex` defining `Demo.Routines.Booking`, and
+  prints the registry entry to add to `Demo.Bot.routines/0`. The registry is
+  string-keyed on purpose — routes resolve by map lookup, never `String.to_atom`.
+  """
+
+  use Mix.Task
+
+  import Mix.Generator
+
+  alias Mix.Virtuoso, as: Gen
+
+  @impl true
+  def run(argv) do
+    case argv do
+      [namespace, name | _] ->
+        {module, path} = Gen.module_arg!(namespace, "bot namespace")
+        {routine, routine_path} = Gen.module_arg!(name, "routine name")
+        generate(module, path, routine, routine_path)
+
+      _ ->
+        Mix.raise("Expected a namespace and a name, e.g.: mix virtuoso.gen.routine Demo Booking")
+    end
+  end
+
+  defp generate(module, path, routine, routine_path) do
+    key = String.replace(routine_path, "/", "_")
+    assigns = [module: module, routine: routine, key: key]
+
+    create_file(
+      Path.join(["lib", path, "routines", "#{routine_path}.ex"]),
+      routine_template(assigns)
+    )
+
+    Mix.shell().info("""
+
+    Add it to #{module}.Bot.routines/0:
+
+        "#{key}" => #{module}.Routines.#{routine}
+
+    or with a per-routine ensemble override:
+
+        "#{key}" => {#{module}.Routines.#{routine}, ensemble: [n: 5, strategy: :judge]}
+    """)
+  end
+
+  embed_template(:routine, """
+  defmodule <%= @module %>.Routines.<%= @routine %> do
+    @moduledoc \"\"\"
+    Handles the "<%= @key %>" intent. Runs exactly once, after the ensemble has
+    committed to this route — put side effects here, never in members.
+    \"\"\"
+
+    @behaviour Virtuoso.Routine
+
+    alias Virtuoso.Impression
+
+    @impl true
+    def run(%Impression{} = impression, _context) do
+      {:reply, "<%= @routine %> is not implemented yet (you said: \#{impression.text})"}
+    end
+  end
+  """)
+end

--- a/lib/mix/tasks/virtuoso.gen.tool.ex
+++ b/lib/mix/tasks/virtuoso.gen.tool.ex
@@ -1,0 +1,70 @@
+defmodule Mix.Tasks.Virtuoso.Gen.Tool do
+  @shortdoc "Generates a Virtuoso tool module (a post-consensus side-effect routine)"
+
+  @moduledoc """
+  Generates a tool under an existing bot namespace:
+
+      mix virtuoso.gen.tool Demo Weather
+
+  creates `lib/demo/tools/weather.ex` defining `Demo.Tools.Weather`.
+
+  In Virtuoso 0.1.0 a *tool* is a `Virtuoso.Routine` in the `Tools` namespace:
+  the ensemble votes on the route, and the winning tool performs its side effect
+  (API call, DB write, message send) **exactly once, post-consensus** — N members
+  never mean N side effects. Register it in the bot's routine registry like any
+  routine.
+  """
+
+  use Mix.Task
+
+  import Mix.Generator
+
+  alias Mix.Virtuoso, as: Gen
+
+  @impl true
+  def run(argv) do
+    case argv do
+      [namespace, name | _] ->
+        {module, path} = Gen.module_arg!(namespace, "bot namespace")
+        {tool, tool_path} = Gen.module_arg!(name, "tool name")
+        generate(module, path, tool, tool_path)
+
+      _ ->
+        Mix.raise("Expected a namespace and a name, e.g.: mix virtuoso.gen.tool Demo Weather")
+    end
+  end
+
+  defp generate(module, path, tool, tool_path) do
+    key = String.replace(tool_path, "/", "_")
+    assigns = [module: module, tool: tool, key: key]
+
+    create_file(Path.join(["lib", path, "tools", "#{tool_path}.ex"]), tool_template(assigns))
+
+    Mix.shell().info("""
+
+    Add it to #{module}.Bot.routines/0:
+
+        "#{key}" => #{module}.Tools.#{tool}
+    """)
+  end
+
+  embed_template(:tool, """
+  defmodule <%= @module %>.Tools.<%= @tool %> do
+    @moduledoc \"\"\"
+    A tool: a routine whose job is a side effect. It runs exactly once, after
+    the ensemble has committed to the "<%= @key %>" route — the consensus layer
+    guarantees N members never trigger N side effects.
+    \"\"\"
+
+    @behaviour Virtuoso.Routine
+
+    alias Virtuoso.Impression
+
+    @impl true
+    def run(%Impression{} = impression, _context) do
+      # Perform the side effect here (HTTP call, DB write, ...), then reply.
+      {:reply, "<%= @tool %> is not implemented yet (you said: \#{impression.text})"}
+    end
+  end
+  """)
+end

--- a/lib/mix/virtuoso.ex
+++ b/lib/mix/virtuoso.ex
@@ -1,0 +1,21 @@
+defmodule Mix.Virtuoso do
+  @moduledoc false
+  # Shared helpers for the virtuoso.gen.* tasks.
+
+  @doc """
+  Validate a CLI argument as an Elixir module namespace (`Demo`, `MyApp.Bots`).
+
+  Returns `{module_string, underscored_path}`; raises `Mix.Error` otherwise.
+  """
+  @spec module_arg!(String.t(), String.t()) :: {String.t(), String.t()}
+  def module_arg!(arg, what) do
+    if arg =~ ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/ do
+      {arg, Macro.underscore(arg)}
+    else
+      Mix.raise(
+        "Expected the #{what} to be a valid module name (e.g. Demo or MyApp.Demo), got: " <>
+          inspect(arg)
+      )
+    end
+  end
+end

--- a/lib/virtuoso/application.ex
+++ b/lib/virtuoso/application.ex
@@ -11,8 +11,8 @@ defmodule Virtuoso.Application do
     # forms before the fabric's Horde components come up on it.
     children =
       Fabric.cluster_children() ++
+        repo_children() ++
         [
-          Virtuoso.Repo,
           # Conversation registry + dynamic supervisor, resolved through the
           # fabric (plain single-node pair by default; Horde when enabled).
           Virtuoso.Conversation.Supervisor,
@@ -24,6 +24,17 @@ defmodule Virtuoso.Application do
 
     opts = [strategy: :one_for_one, name: Virtuoso.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  # Consumers who only use the LLM/Ensemble layers (no conversations) can skip
+  # the Postgres requirement entirely:
+  #
+  #     config :virtuoso, :start_repo, false
+  #
+  # With the repo off, Conversation/Log APIs are unavailable (they raise on
+  # first use); everything else works.
+  defp repo_children do
+    if Application.get_env(:virtuoso, :start_repo, true), do: [Virtuoso.Repo], else: []
   end
 
   # Default budget caps, overridable via `config :virtuoso, Virtuoso.Budget, ...`.

--- a/lib/virtuoso/bot.ex
+++ b/lib/virtuoso/bot.ex
@@ -47,6 +47,13 @@ defmodule Virtuoso.Bot do
   @doc "Default ensemble config for routing (default `[]` → framework defaults)."
   @callback ensemble() :: keyword()
 
+  @doc """
+  The routing system prompt (default `nil` → the framework's built-in router
+  prompt). Generators scaffold this as a **file** under `priv/prompts/` embedded
+  at compile time, not an inline string.
+  """
+  @callback system() :: String.t() | nil
+
   # The generated functions fully-qualify Virtuoso.Bot.* on purpose — aliases
   # don't cross the quote boundary into the using module — so AliasUsage's
   # suggestion doesn't apply to this macro.
@@ -64,7 +71,10 @@ defmodule Virtuoso.Bot do
       @impl true
       def ensemble, do: []
 
-      defoverridable fast: 0, routines: 0, ensemble: 0
+      @impl true
+      def system, do: nil
+
+      defoverridable fast: 0, routines: 0, ensemble: 0, system: 0
 
       @doc "The routine registry with per-routine overrides stripped to modules."
       def routine_registry, do: Virtuoso.Bot.routine_registry(routines())
@@ -109,7 +119,8 @@ defmodule Virtuoso.Bot do
       [
         fast: bot.fast(),
         routines: bot.routine_registry(),
-        ensemble: ensemble_opts
+        ensemble: ensemble_opts,
+        system: bot.system()
       ]
       |> Keyword.merge(opts)
 

--- a/lib/virtuoso/budget.ex
+++ b/lib/virtuoso/budget.ex
@@ -147,10 +147,12 @@ defmodule Virtuoso.Budget do
   usage from its `{:ok, %{usage: ...}}` result, and return that result.
 
   When over budget or killed, `fun` is **not** run; returns
-  `{:error, reason, refusal_message()}` so the caller emits the fallback.
+  `{:refused, reason, refusal_message()}` so the caller emits the fallback.
+  The distinct `:refused` tag (rather than a 3-arity `:error`) means one `case`
+  cleanly separates ok / provider-error / budget-refusal.
   """
   @spec with_budget(name(), String.t(), (-> {:ok, map()} | {:error, term()})) ::
-          {:ok, map()} | {:error, term()} | {:error, atom(), String.t()}
+          {:ok, map()} | {:error, term()} | {:refused, atom(), String.t()}
   def with_budget(server \\ name(), conversation_id, fun) do
     case check(server, conversation_id) do
       :ok ->
@@ -159,7 +161,7 @@ defmodule Virtuoso.Budget do
         result
 
       {:error, reason} ->
-        {:error, reason, @refusal_message}
+        {:refused, reason, @refusal_message}
     end
   end
 

--- a/lib/virtuoso/ensemble/config.ex
+++ b/lib/virtuoso/ensemble/config.ex
@@ -10,7 +10,7 @@ defmodule Virtuoso.Ensemble.Config do
   modules and applying defaults.
 
   `to_ensemble_opts/1` renders the resolved config into the keyword shape
-  `Virtuoso.Thinking.Slow` / `Virtuoso.Ensemble.run/3` expect.
+  `Virtuoso.Thinking.Slow` / `Virtuoso.Ensemble.run/2` expect.
   """
 
   alias Virtuoso.Ensemble.Strategy.{Judge, Majority, Quorum}

--- a/lib/virtuoso/eval/noisy_member.ex
+++ b/lib/virtuoso/eval/noisy_member.ex
@@ -42,7 +42,7 @@ defmodule Virtuoso.Eval.NoisyMember do
   end
 
   @doc """
-  An `Ensemble.run/3`-compatible `:llm` function bound to this task.
+  An `Ensemble.run/2`-compatible `:llm` function bound to this task.
 
   The runner sets `:member` on each member's request; this reads it to vary the
   response per member. Returns `{:ok, completion}` whose `text` is the answer.

--- a/lib/virtuoso/eval/runner.ex
+++ b/lib/virtuoso/eval/runner.ex
@@ -5,7 +5,7 @@ defmodule Virtuoso.Eval.Runner do
   For each task, the runner measures two strategies against the known answer:
 
     * **single-call** — one member's answer (the baseline).
-    * **ensemble** — `Virtuoso.Ensemble.run/3` with N noisy members voting by
+    * **ensemble** — `Virtuoso.Ensemble.run/2` with N noisy members voting by
       majority; the committed (or fallback) decision.
 
   Members err independently (`Virtuoso.Eval.NoisyMember`), so majority-of-N

--- a/lib/virtuoso/migrations.ex
+++ b/lib/virtuoso/migrations.ex
@@ -1,0 +1,50 @@
+defmodule Virtuoso.Migrations do
+  @moduledoc """
+  Migrations for host applications.
+
+  Virtuoso's conversation event log needs one table. From your app, generate a
+  migration and delegate here:
+
+      mix ecto.gen.migration add_virtuoso
+
+      defmodule MyApp.Repo.Migrations.AddVirtuoso do
+        use Ecto.Migration
+
+        def up, do: Virtuoso.Migrations.up()
+        def down, do: Virtuoso.Migrations.down()
+      end
+
+  Future schema versions will keep `up/0` idempotent-forward: it always brings a
+  database to the current version.
+  """
+
+  use Ecto.Migration
+
+  @doc "Create the conversation event log (table + dedup and replay indexes)."
+  def up do
+    create_if_not_exists table(:conversation_events) do
+      add(:conversation_id, :string, null: false)
+      add(:dedup_key, :string, null: false)
+      add(:direction, :string, null: false)
+      add(:role, :string, null: false)
+      add(:content, :text)
+      add(:media, :map, null: false, default: %{})
+      add(:metadata, :map, null: false, default: %{})
+
+      timestamps(updated_at: false, type: :utc_datetime_usec)
+    end
+
+    # Exactly-once: the same channel message (or outbound reply id) can never be
+    # appended twice.
+    create_if_not_exists(unique_index(:conversation_events, [:dedup_key]))
+
+    # Replay/recent-replay filters by conversation_id ordered by id — the
+    # composite serves both as a pure index range scan.
+    create_if_not_exists(index(:conversation_events, [:conversation_id, :id]))
+  end
+
+  @doc "Drop the conversation event log."
+  def down do
+    drop_if_exists(table(:conversation_events))
+  end
+end

--- a/lib/virtuoso/thinking/slow.ex
+++ b/lib/virtuoso/thinking/slow.ex
@@ -9,7 +9,7 @@ defmodule Virtuoso.Thinking.Slow do
   once, not once per member. Consensus is on the decision, not the text; N
   members never mean N replies (or N side effects).
 
-  Flow: build member variants → `Ensemble.run/3` votes on a routine name →
+  Flow: build member variants → `Ensemble.run/2` votes on a routine name →
   resolve the name through the `Virtuoso.Routine` registry (no `String.to_atom`)
   → the routine generates the reply. An unknown/hallucinated route or a failed
   ensemble degrades to a defined fallback reply, never a crash.
@@ -17,7 +17,7 @@ defmodule Virtuoso.Thinking.Slow do
   ## Options
     * `:routines` — `%{name => module}` registry (required).
     * `:ensemble` — `[n: 3, strategy: Majority, models: [...], strategy_opts: ...]`.
-    * `:llm` — the `Ensemble.run/3` `:llm` seam (default `&Virtuoso.LLM.complete/2`).
+    * `:llm` — the `Ensemble.run/2` `:llm` seam (default `&Virtuoso.LLM.complete/2`).
     * `:fallback` — reply text when routing can't resolve (has a sensible default).
     * `:system` — routing system prompt override.
   """
@@ -83,7 +83,7 @@ defmodule Virtuoso.Thinking.Slow do
 
   defp gated_call(llm, budget, conversation_id, request, call_opts) do
     case Budget.with_budget(budget, conversation_id, fn -> llm.(request, call_opts) end) do
-      {:error, reason, _refusal_message} -> {:error, reason}
+      {:refused, reason, _refusal_message} -> {:error, reason}
       other -> other
     end
   end
@@ -99,14 +99,18 @@ defmodule Virtuoso.Thinking.Slow do
     end
   end
 
+  # `:system` (from a bot's prompt file) replaces only the *preamble*; the valid
+  # intent list and reply format are always appended, so a custom prompt can't
+  # silently break routing by omitting the routine names.
   defp routing_request(imp, names, opts) do
-    system =
+    preamble =
       Keyword.get(opts, :system) ||
-        """
-        You are a router. Choose exactly one intent that best handles the user's \
-        message. Valid intents: #{Enum.join(names, ", ")}. Reply with ONLY the \
-        intent name, nothing else.
-        """
+        "You are a router. Choose exactly one intent that best handles the user's message."
+
+    system =
+      String.trim_trailing(preamble) <>
+        "\n\nValid intents: #{Enum.join(names, ", ")}. " <>
+        "Reply with ONLY the intent name, nothing else."
 
     %{
       system: system,

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Virtuoso.MixProject do
   use Mix.Project
 
-  @version "0.1.0-dev"
+  @version "0.1.0"
   @source_url "https://github.com/justuseapen/virtuoso"
 
   def project do
@@ -80,7 +80,7 @@ defmodule Virtuoso.MixProject do
 
   defp package do
     [
-      files: ~w(lib mix.exs README* LICENSE*),
+      files: ~w(lib mix.exs README* LICENSE* CHANGELOG*),
       maintainers: ["Justus Eapen"],
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url}
@@ -90,7 +90,31 @@ defmodule Virtuoso.MixProject do
   defp docs do
     [
       main: "readme",
-      extras: ["README.md"],
+      extras: [
+        "README.md",
+        "CHANGELOG.md",
+        "docs/operations/rolling-deploys.md",
+        "docs/spikes/2026-07-20-horde-spike-report.md"
+      ],
+      groups_for_extras: [
+        Operations: ~r/docs\/operations/,
+        Spikes: ~r/docs\/spikes/
+      ],
+      groups_for_modules: [
+        "Bot API": [Virtuoso.Bot, Virtuoso.Routine, Virtuoso.Thinking, Virtuoso.Thinking.Fast],
+        Ensemble: ~r/Virtuoso\.Ensemble/,
+        Conversations: [
+          Virtuoso.Conversation,
+          Virtuoso.Conversation.Log,
+          Virtuoso.Conversation.Event,
+          Virtuoso.Impression,
+          Virtuoso.Migrations
+        ],
+        "LLM layer": ~r/Virtuoso\.LLM/,
+        "Budget & Fabric": [Virtuoso.Budget, Virtuoso.Fabric],
+        Channels: ~r/Virtuoso\.Channel/,
+        Eval: ~r/Virtuoso\.Eval/
+      ],
       source_ref: "v#{@version}"
     ]
   end

--- a/test/mix/tasks/virtuoso_gen_test.exs
+++ b/test/mix/tasks/virtuoso_gen_test.exs
@@ -1,0 +1,155 @@
+defmodule Mix.Tasks.Virtuoso.GenTest do
+  # File.cd! mutates the process-global cwd, so these can't run alongside others.
+  use ExUnit.Case, async: false
+
+  alias Mix.Tasks.Virtuoso.Gen.{Bot, Routine, Tool}
+  alias Virtuoso.Impression
+
+  setup do
+    Mix.shell(Mix.Shell.Process)
+    on_exit(fn -> Mix.shell(Mix.Shell.IO) end)
+
+    tmp =
+      Path.join(System.tmp_dir!(), "virtuoso_gen_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp)
+    on_exit(fn -> File.rm_rf!(tmp) end)
+
+    {:ok, tmp: tmp}
+  end
+
+  defp in_tmp(tmp, fun), do: File.cd!(tmp, fun)
+
+  # Drain every {:mix_shell, :info, _} message (create_file logs each file, then
+  # the task prints its next-steps hint) and return them all.
+  defp shell_infos(acc \\ []) do
+    receive do
+      {:mix_shell, :info, [msg]} -> shell_infos([msg | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  # Compile a generated file in the tmp project and register cleanup so the
+  # modules don't leak into other tests.
+  defp compile!(path) do
+    modules = Code.compile_string(File.read!(path), path)
+
+    on_exit(fn ->
+      for {mod, _bin} <- modules do
+        :code.purge(mod)
+        :code.delete(mod)
+      end
+    end)
+
+    modules
+  end
+
+  describe "mix virtuoso.gen.bot" do
+    test "generates a bot that compiles and chats via FastThinking", %{tmp: tmp} do
+      in_tmp(tmp, fn ->
+        Bot.run(["Demo"])
+
+        assert File.exists?("lib/demo/bot.ex")
+        assert File.exists?("lib/demo/fast/greeting.ex")
+        assert File.exists?("lib/demo/routines/echo.ex")
+        assert File.exists?("priv/prompts/demo/router.md")
+
+        # Dependency order: matcher + routine first, then the bot (which
+        # references them and embeds the prompt file relative to cwd).
+        compile!("lib/demo/fast/greeting.ex")
+        compile!("lib/demo/routines/echo.ex")
+        compile!("lib/demo/bot.ex")
+
+        imp =
+          Impression.new(
+            channel: :test,
+            conversation_id: "c1",
+            sender_id: "u1",
+            message_id: "m1",
+            text: "hi"
+          )
+
+        # The greeting matcher answers without any LLM call — a crashing :llm
+        # seam proves zero tokens were spent. (Variable-module call: the module
+        # only exists at runtime, so a literal call would warn at compile time.)
+        bot = Module.concat(["Demo", "Bot"])
+        responder = bot.responder(llm: fn _req, _opts -> raise "no LLM expected" end)
+        assert {:reply, reply} = responder.(imp, %{})
+        assert reply =~ "Demo"
+      end)
+    end
+
+    test "the generated system prompt is embedded from the prompt file", %{tmp: tmp} do
+      in_tmp(tmp, fn ->
+        Bot.run(["Demo"])
+        compile!("lib/demo/fast/greeting.ex")
+        compile!("lib/demo/routines/echo.ex")
+        compile!("lib/demo/bot.ex")
+
+        bot = Module.concat(["Demo", "Bot"])
+        system = bot.system()
+        assert system == File.read!("priv/prompts/demo/router.md")
+        assert system =~ "router"
+      end)
+    end
+
+    test "supports nested namespaces", %{tmp: tmp} do
+      in_tmp(tmp, fn ->
+        Bot.run(["MyApp.Support"])
+        assert File.exists?("lib/my_app/support/bot.ex")
+        assert File.exists?("priv/prompts/my_app/support/router.md")
+      end)
+    end
+
+    test "rejects invalid module names" do
+      assert_raise Mix.Error, ~r/valid module name/, fn ->
+        Bot.run(["not_a_module"])
+      end
+
+      assert_raise Mix.Error, ~r/Expected a bot namespace/, fn ->
+        Bot.run([])
+      end
+    end
+  end
+
+  describe "mix virtuoso.gen.routine" do
+    test "generates a compiling routine and prints the registry entry", %{tmp: tmp} do
+      in_tmp(tmp, fn ->
+        Routine.run(["Demo", "Booking"])
+
+        assert File.exists?("lib/demo/routines/booking.ex")
+        [{mod, _} | _] = compile!("lib/demo/routines/booking.ex")
+        assert mod == Demo.Routines.Booking
+
+        imp =
+          Impression.new(
+            channel: :test,
+            conversation_id: "c1",
+            sender_id: "u1",
+            message_id: "m1",
+            text: "book it"
+          )
+
+        assert {:reply, reply} = mod.run(imp, %{})
+        assert reply =~ "book it"
+
+        assert Enum.any?(shell_infos(), &(&1 =~ ~s("booking" => Demo.Routines.Booking)))
+      end)
+    end
+  end
+
+  describe "mix virtuoso.gen.tool" do
+    test "generates a compiling tool in the Tools namespace", %{tmp: tmp} do
+      in_tmp(tmp, fn ->
+        Tool.run(["Demo", "Weather"])
+
+        assert File.exists?("lib/demo/tools/weather.ex")
+        [{mod, _} | _] = compile!("lib/demo/tools/weather.ex")
+        assert mod == Demo.Tools.Weather
+
+        assert Enum.any?(shell_infos(), &(&1 =~ ~s("weather" => Demo.Tools.Weather)))
+      end)
+    end
+  end
+end

--- a/test/virtuoso/budget_test.exs
+++ b/test/virtuoso/budget_test.exs
@@ -71,7 +71,7 @@ defmodule Virtuoso.BudgetTest do
           {:ok, %{usage: %{input_tokens: 1, output_tokens: 1}}}
         end)
 
-      assert result == {:error, :budget_exceeded, Budget.refusal_message()}
+      assert result == {:refused, :budget_exceeded, Budget.refusal_message()}
       refute_received :ran
     end
   end

--- a/todos/007-complete-p2-with-budget-return-shape.md
+++ b/todos/007-complete-p2-with-budget-return-shape.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: complete
 priority: p2
 issue_id: "007"
 tags: [code-review, api, budget, ergonomics]
@@ -51,3 +51,8 @@ _(fill during triage)_
 
 ## Triage Decision
 **DEFERRED** — Real API wart but with_budget/3 has no production callers yet (the thinking pipeline isn't wired). Cheap to fix later with zero migration cost; fix when the first real caller lands so the shape is validated against use.
+
+## Resolution (complete — pre-publish)
+**FIXED** with `{:refused, reason, refusal_message}` (Solution A). Done as a
+Phase 4 pre-publish blocker: a Hex release creates external callers, after which
+the arity-overloaded `:error` would calcify. Spec/docstring/Slow/tests updated.


### PR DESCRIPTION
## Summary
- **Generators**: `mix virtuoso.gen.bot Demo` scaffolds a complete bot — bot module, FastThinking greeting matcher (chats with **zero tokens, no API key**), starter routine, and the routing system prompt as a **file** (`priv/prompts/demo/router.md`, embedded via `@external_resource`). `gen.routine` / `gen.tool` scaffold registry-ready modules (tools = post-consensus side-effect routines in 0.1.0).
- **Prompt-file seam**: new overridable `Virtuoso.Bot.system/0` callback threads the prompt into SlowThinking; `:system` replaces only the router *preamble* — the valid-intent list is always appended so a custom prompt can't silently break routing.
- **`Virtuoso.Migrations`**: Oban-style `up/0`/`down/0` so Hex consumers create `conversation_events` (+ dedup and replay indexes) from their own migration.
- **`config :virtuoso, :start_repo, false`**: LLM/Ensemble-only consumers skip Postgres entirely.
- **Dashboard auth + PII policy**: host-provided plug hook (`config :virtuoso_dashboard, :auth, MyPlug | {MyPlug, opts}`) in the browser pipeline; README documents the PII stance (transcripts only in the event log; telemetry shape-only, test-enforced; ensemble `decision` is categorical, never user text).
- **007 pre-publish API fix**: `Budget.with_budget` refusal now returns `{:refused, reason, msg}` — one `case` cleanly separates ok / provider-error / budget-refusal.
- **Publish prep**: README rewritten for the 0.1.0 surface, CHANGELOG + MIT LICENSE added, ex_doc extras (README/CHANGELOG/rolling-deploys/spike report) + module groups, version `0.1.0`. `mix docs` builds with zero warnings; `mix hex.build` produces a valid package. **`mix hex.publish` is intentionally NOT part of this PR** — it runs only on explicit maintainer go-ahead.

## Testing
- 173 tests, 0 failures — including `--include distributed` chaos drills
- New generator tests: generate into a tmp dir, **compile the generated code**, and drive the bot through `responder/1` with a crashing `:llm` seam to prove the greeting path spends zero tokens
- `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer` all clean; `mix docs` zero warnings; `mix hex.build` validated

## Post-Deploy Monitoring & Validation
- `No additional operational monitoring required`: library + docs changes only; nothing deploys. The one outward-facing step (Hex publish) is deliberately excluded and gated on maintainer approval.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)